### PR TITLE
Fix: Equal height for material cards by adding height style to motion…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9928,21 +9928,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",

--- a/src/pages/TeacherArea/components/Sections/WeekMaterialsList.tsx
+++ b/src/pages/TeacherArea/components/Sections/WeekMaterialsList.tsx
@@ -278,6 +278,7 @@ const WeekMaterialsList = () => {
                                             animate={{ opacity: 1, y: 0 }}
                                             transition={{ duration: 0.4, delay: index * 0.1 }}
                                             whileHover={{ y: -4 }}
+                                            style={{ height: '100%' }} 
                                         >
                                             <Card
                                                 sx={{


### PR DESCRIPTION
Fixed unequal card heights by adding height: '100%' style to motion.div wrapper.

Note: As the app has authentication and route protection, I couldn't fully test this, but I believe this solution should work based on MUI card layout best practices.

Thank you!
